### PR TITLE
[SCR-383] Auto-Mode (mode=auto) node fields

### DIFF
--- a/nodes/ScrapingBee/ScrapingBee.node.ts
+++ b/nodes/ScrapingBee/ScrapingBee.node.ts
@@ -765,6 +765,36 @@ export class ScrapingBee implements INodeType {
 						description: 'Whether to wrap response in JSON or not',
 					},
 					{
+						displayName: 'Max Cost',
+						name: 'maxCost',
+						type: 'number',
+						typeOptions: {
+							minValue: 1,
+						},
+						default: 1,
+						description: 'Max credits a request may cost. Omit for no cap. Requires Mode = Auto.',
+						displayOptions: {
+							show: {
+								mode: ['auto'],
+							},
+						},
+					},
+					{
+						displayName: 'Mode',
+						name: 'mode',
+						type: 'options',
+						options: [
+							{
+								name: 'Auto',
+								value: 'auto',
+							},
+						],
+						// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-options
+						default: '',
+						description:
+							'Auto picks the cheapest scraping config that succeeds (GET only): it tries cheap to expensive, stops at the first success, and charges only for the winning config (0 credits if all fail). Incompatible with Render JS, Premium Proxy and Stealth Proxy (hidden while Auto is selected).',
+					},
+					{
 						displayName: 'Own Proxy',
 						name: 'ownProxy',
 						type: 'string',
@@ -778,6 +808,11 @@ export class ScrapingBee implements INodeType {
 						default: false,
 						description:
 							'Whether to use premium proxies to bypass difficult to scrape websites or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Render JS',
@@ -786,6 +821,11 @@ export class ScrapingBee implements INodeType {
 						default: true,
 						description:
 							'Whether to render the JavaScript on the page with a headless browser or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Return Page Markdown',
@@ -852,6 +892,11 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to use special stealth proxy pool or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Timeout',
@@ -867,6 +912,11 @@ export class ScrapingBee implements INodeType {
 						default: false,
 						description:
 							'Whether to transparently return the same HTTP code of the page requested or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Wait',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-scrapingbee",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "n8n node to call ScrapingBee API services.",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
> **Merge order:** part of the [SCR-383] Auto-Mode client rollout — merge once the server PR ScrapingBee/scrapingbee-API#1242 is merged + the flag is enabled.

## tl;dr

Adds `Mode` (Auto) and `Max Cost` fields to the HTML API node so users can opt into server-side Auto-Mode (`mode=auto`), which escalates cheapest→expensive and charges only the winning config. Opt-in (neutral default), GET-only feature, with incompatible toggles auto-hidden. Build + lint green. **Hold until the API ships `mode=auto`.**

## Summary

- **`nodes/ScrapingBee/ScrapingBee.node.ts`** — two new fields added inside the **`htmlAPI` "Additional Fields"** `collection` (the only block whose keys are auto snake-cased into the request querystring — there is no request-building code to change):
  - **`mode`** — `options` field, single option `{ name: 'Auto', value: 'auto' }`, neutral empty default (`''`) so it's opt-in. Description carries the contract (GET-only cheapest-first escalation, charged only for the winning config, 0 on full failure, incompatible toggles hidden).
  - **`maxCost`** — `type: 'number'`, `typeOptions: { minValue: 1 }`, `displayOptions.show` so it appears **only when `mode = auto`**. Description: "Max credits a request may cost. Omit for no cap. Requires Mode = Auto."
- **Mutual exclusivity** — `displayOptions.hide` (`mode: ['auto']`) added to `renderJs`, `premiumProxy`, `stealthProxy`, **and** `transparentStatusCode` (the four params the server 400s on when combined with `mode=auto`). All are siblings of `mode` within the same `collection`, so plain-name sibling references resolve at render time. Reverse hiding wasn't needed: while `mode=auto` is selected those toggles are hidden, so a server-rejected combo can't be built.
- **`package.json`** — version bumped `0.1.6` → `0.1.7`. No CHANGELOG file exists in the repo, so none was added.

### camel→snake key verification (the critical bit)

The node has no arbitrary key/value entry; for the HTML API it iterates `additionalFields` and snake-cases each key via:
```js
const snakeKey = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
```
I verified this transforms **`maxCost` → `max_cost`** (each uppercase letter → `_` + lowercase) — exactly the API param name — so I named the property `maxCost` and relied on the existing loop (no explicit mapping or request-code change). `mode` is already lowercase → stays `mode`. Confirmed in the compiled `dist` output: both keys present, 5× `mode: ['auto']` (1 `show` + 4 `hide`). The empty-string guard in the same loop (`!== ''`) means a neutral `mode` emits nothing, and an un-added `maxCost` (n8n only serializes explicitly-added collection fields) means **omit = uncapped**, matching the contract.

## Test plan

- [x] `npm install`
- [x] `npm run build` (tsc + gulp icons) — clean
- [x] `npm run lint` (eslint n8n-nodes-base ruleset) — 0 errors/warnings
- [x] prepublish lint (`.eslintrc.prepublish.js`) — clean
- [x] Verified compiled `dist` contains `mode` + `maxCost` and the 5 `displayOptions` rules
- [ ] Manual n8n check (post server-ship): `Mode = Auto` hides Render JS / Premium Proxy / Stealth Proxy / Transparent Status Code; `Max Cost` appears only under Auto; emitted querystring is `&mode=auto[&max_cost=N]`; `Spb-auto-cost` header observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
