### PR TITLE
Sync with latest API docs: Amazon Pricing, Fast Search, Gemini + breaking cleanups (v1.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ n8n 1.101.2 and above
 
 ## Version history
 
-- 0.2.0: Added Amazon Pricing, Fast Search, and Gemini APIs. Added HTML API Auto-Mode (`mode`, `max_cost`) and new Google Search parameters (`light_request`, `pages`, `date_range`, geotargeting, shopping filters, and new search types). Breaking: renamed YouTube Transcript API to YouTube Subtitles API (new `/youtube/subtitles` endpoint, `subtitle_origin` parameter), removed the discontinued YouTube Trainability API, and removed the no-longer-documented `custom_google` (HTML API), `nb_results` (Google Search), and `autoselect_variant` (Amazon Product) fields.
+- 1.0.0: Added Amazon Pricing, Fast Search, and Gemini APIs. Added HTML API Auto-Mode (`mode`, `max_cost`) and new Google Search parameters (`light_request`, `pages`, `date_range`, geotargeting, shopping filters, and new search types). Breaking: renamed YouTube Transcript API to YouTube Subtitles API (new `/youtube/subtitles` endpoint, `subtitle_origin` parameter), removed the discontinued YouTube Trainability API, and removed the no-longer-documented `custom_google` (HTML API), `nb_results` (Google Search), and `autoselect_variant` (Amazon Product) fields.
 - 0.1.6: Added support for YouTube APIs
 - 0.1.5: Added support for Amazon, Walmart, and ChatGPT APIs, and configured it to be used as a tool for AI Agent
 - 0.1.4: Added option to send body in POST and PUT requests, replaced deprecated interface and method, set n8n as user-agent and other minor changes

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 
 - HTML API: GET, POST, PUT
 - Google Search API: GET
+- Fast Search API: GET
+- Amazon Search API: GET
+- Amazon Product API: GET
+- Amazon Pricing API: GET
+- Walmart Search API: GET
+- Walmart Product API: GET
+- YouTube Search API: GET
+- YouTube Metadata API: GET
+- YouTube Subtitles API: GET
+- ChatGPT API: GET
+- Gemini API: GET
 - Usage: GET
 
 ## Credentials
@@ -36,19 +47,25 @@ n8n 1.101.2 and above
 ## Resources
 
 * [n8n community nodes documentation](https://docs.n8n.io/integrations/#community-nodes)
+* [ScrapingBee documentation index](https://www.scrapingbee.com/llms.txt)
 * [HTML API](https://www.scrapingbee.com/documentation/)
 * [Google Search API](https://www.scrapingbee.com/documentation/google/)
+* [Fast Search API](https://www.scrapingbee.com/documentation/fast-search/)
 * [Amazon Search API](https://www.scrapingbee.com/documentation/amazon/#amazon-search-api)
 * [Amazon Product API](https://www.scrapingbee.com/documentation/amazon/#amazon-product-api)
+* [Amazon Pricing API](https://www.scrapingbee.com/documentation/amazon/#amazon-pricing-api)
 * [Walmart Search API](https://www.scrapingbee.com/documentation/walmart/#walmart-search-api)
 * [Walmart Product API](https://www.scrapingbee.com/documentation/walmart/#walmart-product-api)
+* [YouTube APIs](https://www.scrapingbee.com/documentation/youtube/)
 * [ChatGPT API](https://www.scrapingbee.com/documentation/chatgpt/)
+* [Gemini API](https://www.scrapingbee.com/documentation/gemini/)
 * [Usage](https://www.scrapingbee.com/documentation/#usage-endpoint)
 * [Data Extraction](https://www.scrapingbee.com/documentation/data-extraction/)
 * [JavaScript Scenario](https://www.scrapingbee.com/documentation/js-scenario/)
 
 ## Version history
 
+- 0.2.0: Added Amazon Pricing, Fast Search, and Gemini APIs. Added HTML API Auto-Mode (`mode`, `max_cost`) and new Google Search parameters (`light_request`, `pages`, `date_range`, geotargeting, shopping filters, and new search types). Breaking: renamed YouTube Transcript API to YouTube Subtitles API (new `/youtube/subtitles` endpoint, `subtitle_origin` parameter), removed the discontinued YouTube Trainability API, and removed the no-longer-documented `custom_google` (HTML API), `nb_results` (Google Search), and `autoselect_variant` (Amazon Product) fields.
 - 0.1.6: Added support for YouTube APIs
 - 0.1.5: Added support for Amazon, Walmart, and ChatGPT APIs, and configured it to be used as a tool for AI Agent
 - 0.1.4: Added option to send body in POST and PUT requests, replaced deprecated interface and method, set n8n as user-agent and other minor changes

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ n8n 1.101.2 and above
 
 ## Version history
 
-- 1.0.0: Added Amazon Pricing, Fast Search, and Gemini APIs. Added HTML API Auto-Mode (`mode`, `max_cost`) and new Google Search parameters (`light_request`, `pages`, `date_range`, geotargeting, shopping filters, and new search types). Breaking: renamed YouTube Transcript API to YouTube Subtitles API (new `/youtube/subtitles` endpoint, `subtitle_origin` parameter), removed the discontinued YouTube Trainability API, and removed the no-longer-documented `custom_google` (HTML API), `nb_results` (Google Search), and `autoselect_variant` (Amazon Product) fields.
+- 1.0.0: Added Amazon Pricing, Fast Search, and Gemini APIs. Added HTML API Auto-Mode (`mode`, `max_cost`) and new Google Search parameters (`light_request`, `pages`, `date_range`, geotargeting, shopping filters, and new search types). Breaking: renamed YouTube Transcript API to YouTube Subtitles API (new `/youtube/subtitles` endpoint, `subtitle_origin` parameter), and removed the discontinued YouTube Trainability API (the endpoint no longer exists).
 - 0.1.6: Added support for YouTube APIs
 - 0.1.5: Added support for Amazon, Walmart, and ChatGPT APIs, and configured it to be used as a tool for AI Agent
 - 0.1.4: Added option to send body in POST and PUT requests, replaced deprecated interface and method, set n8n as user-agent and other minor changes

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ n8n 1.101.2 and above
 ## Resources
 
 * [n8n community nodes documentation](https://docs.n8n.io/integrations/#community-nodes)
-* [ScrapingBee documentation index](https://www.scrapingbee.com/llms.txt)
 * [HTML API](https://www.scrapingbee.com/documentation/)
 * [Google Search API](https://www.scrapingbee.com/documentation/google/)
 * [Fast Search API](https://www.scrapingbee.com/documentation/fast-search/)

--- a/nodes/ScrapingBee/ScrapingBee.node.ts
+++ b/nodes/ScrapingBee/ScrapingBee.node.ts
@@ -822,9 +822,17 @@ export class ScrapingBee implements INodeType {
 						displayName: 'Max Cost',
 						name: 'maxCost',
 						type: 'number',
-						default: '',
+						typeOptions: {
+							minValue: 1,
+						},
+						default: 1,
 						description:
 							'Maximum credit tier Auto-Mode may attempt (requires Mode to be set to Auto)',
+						displayOptions: {
+							show: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Mode',
@@ -850,6 +858,11 @@ export class ScrapingBee implements INodeType {
 						default: false,
 						description:
 							'Whether to use premium proxies to bypass difficult to scrape websites or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Render JS',
@@ -858,6 +871,11 @@ export class ScrapingBee implements INodeType {
 						default: true,
 						description:
 							'Whether to render the JavaScript on the page with a headless browser or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Return Page Markdown',
@@ -924,6 +942,11 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to use special stealth proxy pool or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Tag',
@@ -947,6 +970,11 @@ export class ScrapingBee implements INodeType {
 						default: false,
 						description:
 							'Whether to transparently return the same HTTP code of the page requested or not',
+						displayOptions: {
+							hide: {
+								mode: ['auto'],
+							},
+						},
 					},
 					{
 						displayName: 'Wait',

--- a/nodes/ScrapingBee/ScrapingBee.node.ts
+++ b/nodes/ScrapingBee/ScrapingBee.node.ts
@@ -40,6 +40,10 @@ export class ScrapingBee implements INodeType {
 				noDataExpression: true,
 				options: [
 					{
+						name: 'Amazon Pricing API',
+						value: 'amazonPricingAPI',
+					},
+					{
 						name: 'Amazon Product API',
 						value: 'amazonProductAPI',
 					},
@@ -50,6 +54,14 @@ export class ScrapingBee implements INodeType {
 					{
 						name: 'ChatGPT API',
 						value: 'chatgptAPI',
+					},
+					{
+						name: 'Fast Search API',
+						value: 'fastSearchAPI',
+					},
+					{
+						name: 'Gemini API',
+						value: 'geminiAPI',
 					},
 					{
 						name: 'Google Search API',
@@ -80,12 +92,8 @@ export class ScrapingBee implements INodeType {
 						value: 'youtubeSearchAPI',
 					},
 					{
-						name: 'YouTube Trainability API',
-						value: 'youtubeTrainabilityAPI',
-					},
-					{
-						name: 'YouTube Transcript API',
-						value: 'youtubeTranscriptAPI',
+						name: 'YouTube Subtitles API',
+						value: 'youtubeSubtitlesAPI',
 					},
 				],
 				default: 'htmlAPI',
@@ -140,6 +148,27 @@ export class ScrapingBee implements INodeType {
 						value: 'get',
 						action: 'Get SERP data using GOOGLE SEARCH API',
 						description: 'Get SERP data using our Google Search API',
+					},
+				],
+				default: 'get',
+			},
+			// Operation for Fast Search API
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['fastSearchAPI'],
+					},
+				},
+				options: [
+					{
+						name: 'GET',
+						value: 'get',
+						action: 'Get lightweight SERP data using FAST SEARCH API',
+						description: 'Get lightweight, low-latency Google search results',
 					},
 				],
 				default: 'get',
@@ -228,6 +257,27 @@ export class ScrapingBee implements INodeType {
 				],
 				default: 'get',
 			},
+			// Operation for Amazon Pricing API
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['amazonPricingAPI'],
+					},
+				},
+				options: [
+					{
+						name: 'GET',
+						value: 'get',
+						action: 'Get pricing offers and seller information using AMAZON PRICING API',
+						description: 'Get pricing, offers, and seller information from Amazon',
+					},
+				],
+				default: 'get',
+			},
 			// Operation for ChatGPT API
 			{
 				displayName: 'Operation',
@@ -245,6 +295,27 @@ export class ScrapingBee implements INodeType {
 						value: 'get',
 						action: 'Get AI response from CHATGPT for your prompt using our CHATGPT API',
 						description: 'Get AI Response from ChatGPT based on your prompt',
+					},
+				],
+				default: 'get',
+			},
+			// Operation for Gemini API
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['geminiAPI'],
+					},
+				},
+				options: [
+					{
+						name: 'GET',
+						value: 'get',
+						action: 'Get AI response from GEMINI for your prompt using our GEMINI API',
+						description: 'Get AI Response from Gemini based on your prompt',
 					},
 				],
 				default: 'get',
@@ -312,7 +383,7 @@ export class ScrapingBee implements INodeType {
 				],
 				default: 'get',
 			},
-			// Operation for YouTube Trainability API
+			// Operation for YouTube Subtitles API
 			{
 				displayName: 'Operation',
 				name: 'operation',
@@ -320,37 +391,15 @@ export class ScrapingBee implements INodeType {
 				noDataExpression: true,
 				displayOptions: {
 					show: {
-						resource: ['youtubeTrainabilityAPI'],
+						resource: ['youtubeSubtitlesAPI'],
 					},
 				},
 				options: [
 					{
 						name: 'GET',
 						value: 'get',
-						action:
-							'Get video transcript availability status from YOUTUBE using our YOUTUBE TRAINABILITY API',
-						description: 'Check if a video has transcripts available for training purposes',
-					},
-				],
-				default: 'get',
-			},
-			// Operation for YouTube Transcript API
-			{
-				displayName: 'Operation',
-				name: 'operation',
-				type: 'options',
-				noDataExpression: true,
-				displayOptions: {
-					show: {
-						resource: ['youtubeTranscriptAPI'],
-					},
-				},
-				options: [
-					{
-						name: 'GET',
-						value: 'get',
-						action: 'Get video transcripts from YOUTUBE using our YOUTUBE TRANSCRIPT API',
-						description: 'Get video transcripts (captions/subtitles)',
+						action: 'Get video subtitles from YOUTUBE using our YOUTUBE SUBTITLES API',
+						description: 'Get video subtitles/captions (transcripts)',
 					},
 				],
 				default: 'get',
@@ -584,7 +633,7 @@ export class ScrapingBee implements INodeType {
 				default: 'pizza',
 				displayOptions: {
 					show: {
-						resource: ['googleSearchAPI', 'youtubeSearchAPI'],
+						resource: ['googleSearchAPI', 'fastSearchAPI', 'youtubeSearchAPI'],
 					},
 				},
 			},
@@ -629,14 +678,27 @@ export class ScrapingBee implements INodeType {
 			},
 			{
 				displayName: 'Prompt',
-				description: 'The prompt you want to send to ChatGPT',
+				description: 'The prompt you want to send to the AI model',
 				required: true,
 				name: 'prompt',
 				type: 'string',
 				default: '',
 				displayOptions: {
 					show: {
-						resource: ['chatgptAPI'],
+						resource: ['chatgptAPI', 'geminiAPI'],
+					},
+				},
+			},
+			{
+				displayName: 'ASIN',
+				description: 'Amazon product identifier (must be a valid 10-character ASIN code)',
+				required: true,
+				name: 'asin',
+				type: 'string',
+				default: '',
+				displayOptions: {
+					show: {
+						resource: ['amazonPricingAPI'],
 					},
 				},
 			},
@@ -649,7 +711,7 @@ export class ScrapingBee implements INodeType {
 				default: '',
 				displayOptions: {
 					show: {
-						resource: ['youtubeMetadataAPI', 'youtubeTrainabilityAPI', 'youtubeTranscriptAPI'],
+						resource: ['youtubeMetadataAPI', 'youtubeSubtitlesAPI'],
 					},
 				},
 			},
@@ -717,14 +779,6 @@ export class ScrapingBee implements INodeType {
 						description: 'Premium proxy geolocation',
 					},
 					{
-						displayName: 'Custom Google',
-						name: 'customGoogle',
-						type: 'boolean',
-						default: false,
-						description:
-							'Whether you are scraping Google domains or not? Set to true to scrape Google',
-					},
-					{
 						displayName: 'Device',
 						name: 'device',
 						type: 'options',
@@ -763,6 +817,24 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to wrap response in JSON or not',
+					},
+					{
+						displayName: 'Max Cost',
+						name: 'maxCost',
+						type: 'number',
+						default: '',
+						description:
+							'Maximum credit tier Auto-Mode may attempt (requires Mode to be set to Auto)',
+					},
+					{
+						displayName: 'Mode',
+						name: 'mode',
+						type: 'options',
+						description:
+							'Auto-Mode escalates through proxy/rendering tiers until one succeeds and only charges the successful tier. GET only; cannot be combined with Render JS, Premium Proxy, Stealth Proxy, or Transparent Status Code.',
+						options: [{ name: 'Auto', value: 'auto' }],
+						// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-options
+						default: '',
 					},
 					{
 						displayName: 'Own Proxy',
@@ -854,6 +926,14 @@ export class ScrapingBee implements INodeType {
 						description: 'Whether to use special stealth proxy pool or not',
 					},
 					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+					{
 						displayName: 'Timeout',
 						name: 'timeout',
 						type: 'number',
@@ -941,6 +1021,22 @@ export class ScrapingBee implements INodeType {
 						description: 'Country code from which you would like the request to come from',
 					},
 					{
+						displayName: 'Date Range',
+						name: 'dateRange',
+						type: 'options',
+						description:
+							'Filter results by date; only applies to classic, news, and images search types',
+						options: [
+							{ name: 'Any Time', value: '' },
+							{ name: 'Past Day', value: 'past_day' },
+							{ name: 'Past Hour', value: 'past_hour' },
+							{ name: 'Past Month', value: 'past_month' },
+							{ name: 'Past Week', value: 'past_week' },
+							{ name: 'Past Year', value: 'past_year' },
+						],
+						default: '',
+					},
+					{
 						displayName: 'Device',
 						name: 'device',
 						type: 'options',
@@ -975,11 +1071,42 @@ export class ScrapingBee implements INodeType {
 						description: 'Language the search results will be displayed in',
 					},
 					{
-						displayName: 'Number of Results',
-						name: 'nbResults',
-						type: 'number',
-						default: 100,
-						description: 'The number of results you want to get back from Google Search',
+						displayName: 'Latitude',
+						name: 'latitude',
+						type: 'string',
+						default: '',
+						description:
+							'Latitude in decimal degrees for geo-targeted search; must be supplied together with longitude',
+					},
+					{
+						displayName: 'Light Request',
+						name: 'lightRequest',
+						type: 'boolean',
+						default: true,
+						description:
+							'Whether to use a light request (faster and cheaper). Set to false to force a regular browser request, which is needed for AI Overviews.',
+					},
+					{
+						displayName: 'Longitude',
+						name: 'longitude',
+						type: 'string',
+						default: '',
+						description:
+							'Longitude in decimal degrees for geo-targeted search; must be supplied together with latitude',
+					},
+					{
+						displayName: 'Max Price',
+						name: 'maxPrice',
+						type: 'string',
+						default: '',
+						description: 'Maximum price filter; only applies to the shopping search type',
+					},
+					{
+						displayName: 'Min Price',
+						name: 'minPrice',
+						type: 'string',
+						default: '',
+						description: 'Minimum price filter; only applies to the shopping search type',
 					},
 					{
 						displayName: 'Page',
@@ -989,16 +1116,59 @@ export class ScrapingBee implements INodeType {
 						description: 'The page number you want to extract results from',
 					},
 					{
+						displayName: 'Pages',
+						name: 'pages',
+						type: 'number',
+						default: 1,
+						description:
+							'Number of consecutive pages to fetch and combine (max 10; 3 or fewer recommended)',
+					},
+					{
+						displayName: 'Radius',
+						name: 'radius',
+						type: 'string',
+						default: '',
+						description:
+							'Radius in meters around latitude/longitude; only takes effect when both are supplied',
+					},
+					{
 						displayName: 'Search Type',
 						name: 'searchType',
 						type: 'options',
-						description: 'The type of search you want to perform, (classic, news or maps)',
+						description: 'The type of search you want to perform',
 						options: [
+							{ name: 'Ads', value: 'ads' },
+							{ name: 'AI Mode', value: 'ai_mode' },
 							{ name: 'Classic', value: 'classic' },
-							{ name: 'News', value: 'news' },
+							{ name: 'Images', value: 'images' },
+							{ name: 'Lens', value: 'lens' },
 							{ name: 'Maps', value: 'maps' },
+							{ name: 'News', value: 'news' },
+							{ name: 'Shopping', value: 'shopping' },
 						],
 						default: 'classic',
+					},
+					{
+						displayName: 'Sort By',
+						name: 'sortBy',
+						type: 'options',
+						description: 'Sort order for results; only applies to the shopping search type',
+						options: [
+							{ name: 'Price High To Low', value: 'price_desc' },
+							{ name: 'Price Low To High', value: 'price_asc' },
+							{ name: 'Relevance', value: 'relevance' },
+							{ name: 'Reviews', value: 'reviews' },
+						],
+						// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-options
+						default: '',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
 					},
 				],
 			},
@@ -1094,6 +1264,14 @@ export class ScrapingBee implements INodeType {
 						description: 'Minimum price filter',
 					},
 					{
+						displayName: 'Screenshot',
+						name: 'screenshot',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to force a browser screenshot (returned base64-encoded, costs 15 credits, ignores Light Request) or not',
+					},
+					{
 						displayName: 'Sort By',
 						name: 'sortBy',
 						type: 'options',
@@ -1107,11 +1285,26 @@ export class ScrapingBee implements INodeType {
 						default: 'best_match',
 					},
 					{
+						displayName: 'Start Page',
+						name: 'startPage',
+						type: 'number',
+						default: 1,
+						description: 'Page of the results to fetch',
+					},
+					{
 						displayName: 'Store ID',
 						name: 'storeId',
 						type: 'string',
 						default: '',
 						description: 'Specific Walmart store ID for localization',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
 					},
 				],
 			},
@@ -1170,11 +1363,27 @@ export class ScrapingBee implements INodeType {
 							'Whether to use it without JavaScript-rendering or not. If false, forces JavaScript-rendered results.',
 					},
 					{
+						displayName: 'Screenshot',
+						name: 'screenshot',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to force a browser screenshot (returned base64-encoded, costs 15 credits, ignores Light Request) or not',
+					},
+					{
 						displayName: 'Store ID',
 						name: 'storeId',
 						type: 'string',
 						default: '',
 						description: 'Specific Walmart store ID for localization',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
 					},
 				],
 			},
@@ -1197,6 +1406,14 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to add the full html of the page in the results or not',
+					},
+					{
+						displayName: 'Autoselect Variant',
+						name: 'autoselectVariant',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to automatically select the default/most popular product variant or not',
 					},
 					{
 						displayName: 'Category ID',
@@ -1270,6 +1487,14 @@ export class ScrapingBee implements INodeType {
 						description: 'Number of result pages to fetch',
 					},
 					{
+						displayName: 'Screenshot',
+						name: 'screenshot',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to force a browser screenshot (returned base64-encoded, costs 15 credits, ignores Light Request) or not',
+					},
+					{
 						displayName: 'Sort By',
 						name: 'sortBy',
 						type: 'options',
@@ -1291,6 +1516,14 @@ export class ScrapingBee implements INodeType {
 						type: 'number',
 						default: 1,
 						description: 'First page of the results to fetch',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
 					},
 					{
 						displayName: 'Zip Code',
@@ -1320,13 +1553,6 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to add the full html of the page in the results or not',
-					},
-					{
-						displayName: 'Autoselect Variant',
-						name: 'autoselectVariant',
-						type: 'boolean',
-						default: false,
-						description: 'Whether to automatically select product variant if applicable or not',
 					},
 					{
 						displayName: 'Country',
@@ -1379,6 +1605,104 @@ export class ScrapingBee implements INodeType {
 							'Whether to use it without JavaScript-rendering or not. If false, forces JavaScript-rendered results.',
 					},
 					{
+						displayName: 'Screenshot',
+						name: 'screenshot',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to force a browser screenshot (returned base64-encoded, costs 15 credits, ignores Light Request) or not',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+					{
+						displayName: 'Zip Code',
+						name: 'zipCode',
+						type: 'string',
+						default: '',
+						description: 'ZIP or postal code for geolocation',
+					},
+				],
+			},
+			// Additional Fields for Amazon Pricing API
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				default: {},
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['amazonPricingAPI'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Add HTML',
+						name: 'addHtml',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to add the full html of the page in the results or not',
+					},
+					{
+						displayName: 'Country',
+						name: 'country',
+						type: 'string',
+						default: '',
+						description:
+							'Country code for geolocation of the request. Must not match the domain\'s own country; use Zip Code instead in that case.',
+					},
+					{
+						displayName: 'Currency',
+						name: 'currency',
+						type: 'string',
+						default: '',
+						description: 'Currency code (ISO 4217) to display results',
+					},
+					{
+						displayName: 'Device',
+						name: 'device',
+						type: 'options',
+						description: 'Control the device the request will be sent from',
+						options: [{ name: 'Desktop', value: 'desktop' }],
+						default: 'desktop',
+					},
+					{
+						displayName: 'Domain',
+						name: 'domain',
+						type: 'string',
+						default: 'com',
+						description: 'Top-level domain to use (e.g., com, co.uk, de)',
+					},
+					{
+						displayName: 'Language',
+						name: 'language',
+						type: 'string',
+						default: '',
+						description: 'Language code for the request (ISO format)',
+					},
+					{
+						displayName: 'Light Request',
+						name: 'lightRequest',
+						type: 'boolean',
+						default: true,
+						description:
+							'Whether to use it without JavaScript-rendering or not. If false, forces JavaScript-rendered results.',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+					{
 						displayName: 'Zip Code',
 						name: 'zipCode',
 						type: 'string',
@@ -1420,6 +1744,95 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to enable web search to enhance the GPT response or not',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+				],
+			},
+			// Additional Fields for Gemini API
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				default: {},
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['geminiAPI'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Add HTML',
+						name: 'addHtml',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to add the full html of the page in the results or not',
+					},
+					{
+						displayName: 'Country Code',
+						name: 'countryCode',
+						type: 'string',
+						default: '',
+						description: 'Country code from which you would like the request to come from',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+				],
+			},
+			// Additional Fields for Fast Search API
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				default: {},
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['fastSearchAPI'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Country Code',
+						name: 'countryCode',
+						type: 'string',
+						default: 'us',
+						description: 'Country code used to localize the search results (ISO 3166-1 alpha-2)',
+					},
+					{
+						displayName: 'Language',
+						name: 'language',
+						type: 'string',
+						default: 'en',
+						description: 'Language the search results will be displayed in',
+					},
+					{
+						displayName: 'Page',
+						name: 'page',
+						type: 'number',
+						default: 1,
+						description: 'The page number you want to extract results from',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
 					},
 				],
 			},
@@ -1548,6 +1961,14 @@ export class ScrapingBee implements INodeType {
 						description: 'Whether to return only videos with subtitles/closed captions or not',
 					},
 					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+					{
 						displayName: 'Upload Date',
 						name: 'upload_date',
 						type: 'options',
@@ -1571,7 +1992,7 @@ export class ScrapingBee implements INodeType {
 					},
 				],
 			},
-			// Additional Fields for YouTube Transcript API
+			// Additional Fields for YouTube Metadata API
 			{
 				displayName: 'Additional Fields',
 				name: 'additionalFields',
@@ -1580,7 +2001,30 @@ export class ScrapingBee implements INodeType {
 				placeholder: 'Add Field',
 				displayOptions: {
 					show: {
-						resource: ['youtubeTranscriptAPI'],
+						resource: ['youtubeMetadataAPI'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
+					},
+				],
+			},
+			// Additional Fields for YouTube Subtitles API
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				default: {},
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						resource: ['youtubeSubtitlesAPI'],
 					},
 				},
 				options: [
@@ -1589,18 +2033,26 @@ export class ScrapingBee implements INodeType {
 						name: 'language',
 						type: 'string',
 						default: 'en',
-						description: 'Transcript language (ISO code)',
+						description: 'Subtitle language (ISO code)',
 					},
 					{
-						displayName: 'Transcript Origin',
-						name: 'transcript_origin',
+						displayName: 'Subtitle Origin',
+						name: 'subtitle_origin',
 						type: 'options',
-						description: 'Choose auto-generated or uploader-provided transcripts',
+						description: 'Choose auto-generated or uploader-provided subtitles',
 						options: [
 							{ name: 'Auto Generated', value: 'auto_generated' },
 							{ name: 'Uploader Provided', value: 'uploader_provided' },
 						],
 						default: 'auto_generated',
+					},
+					{
+						displayName: 'Tag',
+						name: 'tag',
+						type: 'string',
+						default: '',
+						description:
+							'Label returned in the response headers; does not affect scraping behavior',
 					},
 				],
 			},
@@ -1725,6 +2177,21 @@ export class ScrapingBee implements INodeType {
 							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
 						}
 					});
+				} else if (resource === 'fastSearchAPI') {
+					endpoint = 'https://app.scrapingbee.com/api/v1/fast_search';
+					requestOptions.method = 'GET';
+					scrapingBeeUrlParams.search = this.getNodeParameter('search', i) as string;
+					const additionalFields = this.getNodeParameter('additionalFields', i, {}) as any;
+					Object.keys(additionalFields).forEach((key) => {
+						const snakeKey = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+						if (
+							additionalFields[key] !== '' &&
+							additionalFields[key] !== undefined &&
+							additionalFields[key] !== null
+						) {
+							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
+						}
+					});
 				} else if (resource === 'walmartSearchAPI') {
 					endpoint = 'https://app.scrapingbee.com/api/v1/walmart/search';
 					requestOptions.method = 'GET';
@@ -1785,8 +2252,38 @@ export class ScrapingBee implements INodeType {
 							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
 						}
 					});
+				} else if (resource === 'amazonPricingAPI') {
+					endpoint = 'https://app.scrapingbee.com/api/v1/amazon/pricing';
+					requestOptions.method = 'GET';
+					scrapingBeeUrlParams.asin = this.getNodeParameter('asin', i) as string;
+					const additionalFields = this.getNodeParameter('additionalFields', i, {}) as any;
+					Object.keys(additionalFields).forEach((key) => {
+						const snakeKey = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+						if (
+							additionalFields[key] !== '' &&
+							additionalFields[key] !== undefined &&
+							additionalFields[key] !== null
+						) {
+							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
+						}
+					});
 				} else if (resource === 'chatgptAPI') {
 					endpoint = 'https://app.scrapingbee.com/api/v1/chatgpt';
+					requestOptions.method = 'GET';
+					scrapingBeeUrlParams.prompt = this.getNodeParameter('prompt', i) as string;
+					const additionalFields = this.getNodeParameter('additionalFields', i, {}) as any;
+					Object.keys(additionalFields).forEach((key) => {
+						const snakeKey = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+						if (
+							additionalFields[key] !== '' &&
+							additionalFields[key] !== undefined &&
+							additionalFields[key] !== null
+						) {
+							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
+						}
+					});
+				} else if (resource === 'geminiAPI') {
+					endpoint = 'https://app.scrapingbee.com/api/v1/gemini';
 					requestOptions.method = 'GET';
 					scrapingBeeUrlParams.prompt = this.getNodeParameter('prompt', i) as string;
 					const additionalFields = this.getNodeParameter('additionalFields', i, {}) as any;
@@ -1830,8 +2327,8 @@ export class ScrapingBee implements INodeType {
 							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
 						}
 					});
-				} else if (resource === 'youtubeTrainabilityAPI') {
-					endpoint = 'https://app.scrapingbee.com/api/v1/youtube/trainability';
+				} else if (resource === 'youtubeSubtitlesAPI') {
+					endpoint = 'https://app.scrapingbee.com/api/v1/youtube/subtitles';
 					requestOptions.method = 'GET';
 					scrapingBeeUrlParams.video_id = this.getNodeParameter('videoId', i) as string;
 					const additionalFields = this.getNodeParameter('additionalFields', i, {}) as any;
@@ -1845,25 +2342,15 @@ export class ScrapingBee implements INodeType {
 							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
 						}
 					});
-				} else if (resource === 'youtubeTranscriptAPI') {
-					endpoint = 'https://app.scrapingbee.com/api/v1/youtube/transcript';
-					requestOptions.method = 'GET';
-					scrapingBeeUrlParams.video_id = this.getNodeParameter('videoId', i) as string;
-					const additionalFields = this.getNodeParameter('additionalFields', i, {}) as any;
-					Object.keys(additionalFields).forEach((key) => {
-						const snakeKey = key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-						if (
-							additionalFields[key] !== '' &&
-							additionalFields[key] !== undefined &&
-							additionalFields[key] !== null
-						) {
-							scrapingBeeUrlParams[snakeKey] = additionalFields[key];
-						}
-					});
-				} else {
-					// usage
+				} else if (resource === 'usage') {
 					endpoint = 'https://app.scrapingbee.com/api/v1/usage';
 					requestOptions.method = 'GET';
+				} else {
+					throw new NodeOperationError(
+						this.getNode(),
+						`The resource "${resource}" is not supported. It may have been renamed or removed in this version of the node; please reconfigure the node.`,
+						{ itemIndex: i },
+					);
 				}
 
 				// Assign all collected URL parameters and the final URL to the request options

--- a/nodes/ScrapingBee/ScrapingBee.node.ts
+++ b/nodes/ScrapingBee/ScrapingBee.node.ts
@@ -1061,7 +1061,7 @@ export class ScrapingBee implements INodeType {
 						type: 'string',
 						default: '',
 						description: 'Extra Google URL parameters',
-						hint: 'You can also pass multiple parameters, separated by &: example: tbs=qdr:d&lr=lang_fr',
+						hint: 'Allowed keys: filter, fpstate, locale, nfpr, tbm, tbs, udm. You can pass multiple parameters separated by &, example: tbs=qdr:d&filter=0',
 					},
 					{
 						displayName: 'Language',
@@ -1232,15 +1232,15 @@ export class ScrapingBee implements INodeType {
 						// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-options
 						default: '',
 					},
-					{
-						displayName: 'Fulfillment Type',
-						name: 'fulfillmentType',
-						type: 'options',
-						description: 'Fulfillment type filter',
-						options: [{ name: 'In Store', value: 'in_store' }],
-						// eslint-disable-next-line n8n-nodes-base/node-param-default-wrong-for-options
-						default: '',
-					},
+					// NOT WORKING IN API
+					// {
+					// 	displayName: 'Fulfillment Type',
+					// 	name: 'fulfillmentType',
+					// 	type: 'options',
+					// 	description: 'Fulfillment type filter',
+					// 	options: [{ name: 'In Store', value: 'in_store' }],
+					// 	default: '',
+					// },
 					{
 						displayName: 'Light Request',
 						name: 'lightRequest',
@@ -1420,7 +1420,7 @@ export class ScrapingBee implements INodeType {
 						name: 'categoryId',
 						type: 'string',
 						default: '',
-						description: 'Filter search results by category ID',
+						description: 'Filter search results by numeric category ID (Amazon browse node ID)',
 					},
 					{
 						displayName: 'Country',
@@ -1679,13 +1679,14 @@ export class ScrapingBee implements INodeType {
 						default: 'com',
 						description: 'Top-level domain to use (e.g., com, co.uk, de)',
 					},
-					{
-						displayName: 'Language',
-						name: 'language',
-						type: 'string',
-						default: '',
-						description: 'Language code for the request (ISO format)',
-					},
+					// NOT WORKING IN API
+					// {
+					// 	displayName: 'Language',
+					// 	name: 'language',
+					// 	type: 'string',
+					// 	default: '',
+					// 	description: 'Language code for the request (ISO format)',
+					// },
 					{
 						displayName: 'Light Request',
 						name: 'lightRequest',

--- a/nodes/ScrapingBee/ScrapingBee.node.ts
+++ b/nodes/ScrapingBee/ScrapingBee.node.ts
@@ -779,6 +779,14 @@ export class ScrapingBee implements INodeType {
 						description: 'Premium proxy geolocation',
 					},
 					{
+						displayName: 'Custom Google',
+						name: 'customGoogle',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether you are scraping a Google domain or not. Required to scrape Google domains; each request costs 20 credits.',
+					},
+					{
 						displayName: 'Device',
 						name: 'device',
 						type: 'options',
@@ -1135,6 +1143,13 @@ export class ScrapingBee implements INodeType {
 						type: 'string',
 						default: '',
 						description: 'Minimum price filter; only applies to the shopping search type',
+					},
+					{
+						displayName: 'Number of Results',
+						name: 'nbResults',
+						type: 'number',
+						default: 100,
+						description: 'The number of results you want to get back from Google Search',
 					},
 					{
 						displayName: 'Page',
@@ -1581,6 +1596,13 @@ export class ScrapingBee implements INodeType {
 						type: 'boolean',
 						default: false,
 						description: 'Whether to add the full html of the page in the results or not',
+					},
+					{
+						displayName: 'Autoselect Variant',
+						name: 'autoselectVariant',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to automatically select product variant if applicable or not',
 					},
 					{
 						displayName: 'Country',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-scrapingbee",
-	"version": "0.1.6",
+	"version": "0.2.0",
 	"description": "n8n node to call ScrapingBee API services.",
 	"keywords": [
 		"n8n-community-node-package"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-scrapingbee",
-	"version": "0.2.0",
+	"version": "1.0.0",
 	"description": "n8n node to call ScrapingBee API services.",
 	"keywords": [
 		"n8n-community-node-package"


### PR DESCRIPTION
Brings the node in line with the current API surface and bumps to 1.0.0 since there are breaking changes.

**New**
- Amazon Pricing, Fast Search and Gemini resources
- HTML API Auto-Mode (`mode` + `max_cost`); incompatible toggles auto-hide while Auto is selected (adopted from #4 — thanks @kostas-jakeliunas-sb, this supersedes it)
- Google Search: shopping/images/lens/ai_mode/ads search types, `date_range`, geotargeting and shopping filters
- `screenshot`, `tag`, `start_page` and other newly documented fields across Amazon, Walmart, YouTube and ChatGPT

**Breaking**
- YouTube Transcript API → YouTube Subtitles API (`/youtube/subtitles`, `subtitle_origin`)
- Removed YouTube Trainability API (endpoint no longer exists)
- ~~Removed undocumented params~~ `custom_google`, `nb_results` and `autoselect_variant` were re-verified against the live API and kept (`custom_google` is still required for Google domains)
- Workflows still using a removed resource now fail with a clear error instead of silently calling /usage

**Testing**
Every resource and parameter was executed through a local n8n instance against the live API (~60 workflows). Two documented params consistently 500 server-side (Amazon Pricing `language`, Walmart Search `fulfillment_type`) and are commented out like the other NOT WORKING IN API fields.

Closes #4.